### PR TITLE
Refine README: anonymize header, de-emphasize student status, emphasize reverse engineering & maldev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,70 @@
-# Welcome !!
+# Offensive Security / AppSec
 
-*Grunt@G4sp4rCS-gh: ~$ whoami*
-*Grunt*
+**Buenos Aires, Argentina 🇦🇷**
 
-------
+[![Website](https://img.shields.io/badge/Website-grunt.ar-0A0A0A?style=for-the-badge&logo=google-chrome&logoColor=white)](https://grunt.ar/)
+[![Blog](https://img.shields.io/badge/Blog-blog.grunt.ar-0A0A0A?style=for-the-badge&logo=ghost&logoColor=white)](https://blog.grunt.ar/)
 
-Hi everyone! My name is Gaspar Onesto — I'm currently looking for roles in Offensive Security or AppSec.
-- 🔭 I'm a grad student @ [DC-UBA](https://www.dc.uba.ar/).
-- 📍 Based in Buenos Aires, Argentina  🇦🇷 
-- 🎓 CS student with 3+ years of professional experience in Pentesting and Application Security
-- 🔒 Strong background in:
-    - Web & AppSec
-    -Secure code review, SAST/DAST tooling
-    - Threat simulations in Linux, Windows, and cloud environments
-    - Vulnerability discovery and offensive scripting
+---
 
-- 🎓 Currently expanding into Red Teaming and Exploit Development via pwn.college and Maldev Academy.
+## 👋 About
 
--------
+- **3+ years** of professional experience in **Pentesting** and **Application Security**.
+- Strong focus on **Web/AppSec**, **secure code review**, **SAST/DAST**, and **threat simulations** (Linux, Windows, cloud).
+- Deepening expertise in **Reverse Engineering** and **Malware Development** (pwn.college + Maldev Academy).
+- Currently working in **AppSec**.
+- CS background (DC-UBA).
 
-- 📜 Certifications:
-   - OSCP+
-   - PNPT (TCM Security)
-   - CPTS (HTB)
-   - eWPTv2 / eJPTv2 (INE)
-- 3 ProLabs completed on HTB (Dante, Zephyr, Rasta)
+---
 
--------
+## 🎯 Focus Areas
 
-- 👨‍💻 I’m currently working in AppSec
-- ⚡I have a strong passion for offensive security and applied research in cybersecurity.
+- Reverse engineering & malware development
+- Web & application security
+- Secure code review, SAST/DAST
+- Offensive scripting & automation
+- Vulnerability research & exploitation
+- Red team tradecraft
 
- [Check my website](https://grunt.ar/) //
- [Check my blog](https://blog.grunt.ar/)
+---
+
+## 📜 Certifications
+
+- **OSCP+**
+- **PNPT (TCM Security)**
+- **CPTS (HTB)**
+- **eWPTv2 / eJPTv2 (INE)**
+- ✅ 3 ProLabs completed on HTB (Dante, Zephyr, Rasta)
+
+### Badges
+
+![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/154955830)
+![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/139940775)
+![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/93944403)
+![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/81521112)
+![Credly Badge](https://images.credly.com/size/340x340/images/e63aa507-b974-4e67-bae6-1e425f6e2a99/image.png)
+
+---
+
+## 🧰 Tooling (shields.io)
+
+![Kali Linux](https://img.shields.io/badge/Kali%20Linux-557C94?style=for-the-badge&logo=kali-linux&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
+![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+![Nmap](https://img.shields.io/badge/Nmap-004170?style=for-the-badge&logo=nmap&logoColor=white)
+![Burp Suite](https://img.shields.io/badge/Burp%20Suite-FF6633?style=for-the-badge&logo=burp-suite&logoColor=white)
+![Metasploit](https://img.shields.io/badge/Metasploit-2A2A2A?style=for-the-badge&logo=metasploit&logoColor=white)
+![Wireshark](https://img.shields.io/badge/Wireshark-1679A7?style=for-the-badge&logo=wireshark&logoColor=white)
+
+---
+
+## 📫 Contact
+
+- 🌐 Website: [grunt.ar](https://grunt.ar/)
+- ✍️ Blog: [blog.grunt.ar](https://blog.grunt.ar/)
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@
 
 ---
 
-## 👋 About
+## About me
 
 - **3+ years** of professional experience in **Pentesting** and **Application Security**.
 - Strong focus on **Web/AppSec**, **secure code review**, **SAST/DAST**, and **threat simulations** (Linux, Windows, cloud).
-- Deepening expertise in **Reverse Engineering** and **Malware Development** (pwn.college + Maldev Academy).
+- Deepening expertise in **Reverse Engineering**, **Binary Exploitation**, and **Malware Development**.
 - Currently working in **AppSec**.
-- CS background (DC-UBA).
+- CS background [DC-UBA](https://www.dc.uba.ar/).
 
 ---
 
-## 🎯 Focus Areas
+## Focus Areas
 
-- Reverse engineering & malware development
+- Reverse engineering, binary exploitation.
+- Malware analysis & development
 - Web & application security
 - Secure code review, SAST/DAST
 - Offensive scripting & automation
@@ -34,37 +35,59 @@
 - **PNPT (TCM Security)**
 - **CPTS (HTB)**
 - **eWPTv2 / eJPTv2 (INE)**
-- ✅ 3 ProLabs completed on HTB (Dante, Zephyr, Rasta)
+- 3 ProLabs completed on HTB (Dante, Zephyr, Rasta)
 
 ### Badges
 
-![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/154955830)
-![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/139940775)
-![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/93944403)
-![Accredible Badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/81521112)
-![Credly Badge](https://images.credly.com/size/340x340/images/e63aa507-b974-4e67-bae6-1e425f6e2a99/image.png)
+[![OSCP+ badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/154955830)](https://credentials.offsec.com/d48b2fbe-1b3e-415d-ac42-4ec17306d895)
+[![PNPT badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/139940775)](https://certified.tcm-sec.com/76169ba5-9caf-44c0-96b4-6f76b342f0c4)
+[![CPTS (HTB) badge](https://images.credly.com/size/150x150/images/e63aa507-b974-4e67-bae6-1e425f6e2a99/image.png)](https://www.credly.com/badges/2a9e3b5b-f684-45d9-ab2d-a74e7cf9714e/public_url)
+[![eWPTv2 badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/93944403)](https://certs.ine.com/51afc7c9-f3f7-4a08-a41a-47d7f179b492)
+[![eJPTv2 badge](https://api.accredible.com/v1/frontend/credential_website_embed_image/badge/81521112)](https://certs.ine.com/91b88470-734b-4cb6-b495-d7dfcb3b476f)
 
 ---
 
-## 🧰 Tooling (shields.io)
+## Technical Stack
 
+**Focus**
+![Ethical Hacking](https://img.shields.io/badge/Ethical%20Hacking-111111?style=for-the-badge)
+![OSINT](https://img.shields.io/badge/OSINT-2C3E50?style=for-the-badge)
+![DevSecOps](https://img.shields.io/badge/DevSecOps-0F172A?style=for-the-badge)
+![SDLC & AppSec](https://img.shields.io/badge/SDLC%20%26%20AppSec-1F2937?style=for-the-badge)
+![Windows Internals](https://img.shields.io/badge/Windows%20Internals-0078D6?style=for-the-badge&logo=windows&logoColor=white)
+
+**Platforms**
 ![Kali Linux](https://img.shields.io/badge/Kali%20Linux-557C94?style=for-the-badge&logo=kali-linux&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
+
+**Cloud & Infrastructure**
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=amazonaws&logoColor=white)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+
+**Languages & Scripting**
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+
+![NodeJS](https://img.shields.io/badge/NodeJS-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+
 ![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
 ![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
-![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
+![Java](https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)
+![C](https://img.shields.io/badge/C-A8B9CC?style=for-the-badge&logo=c&logoColor=black)
+![C++](https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=cplusplus&logoColor=white)
+
+**Security & Ops**
 ![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
 ![Nmap](https://img.shields.io/badge/Nmap-004170?style=for-the-badge&logo=nmap&logoColor=white)
 ![Burp Suite](https://img.shields.io/badge/Burp%20Suite-FF6633?style=for-the-badge&logo=burp-suite&logoColor=white)
 ![Metasploit](https://img.shields.io/badge/Metasploit-2A2A2A?style=for-the-badge&logo=metasploit&logoColor=white)
 ![Wireshark](https://img.shields.io/badge/Wireshark-1679A7?style=for-the-badge&logo=wireshark&logoColor=white)
+![IDA Pro](https://img.shields.io/badge/IDA%20Pro-1D1D1D?style=for-the-badge)
 
 ---
 
-## 📫 Contact
+#### Contact
 
-- 🌐 Website: [grunt.ar](https://grunt.ar/)
-- ✍️ Blog: [blog.grunt.ar](https://blog.grunt.ar/)
-
+gruntsec@pm.me


### PR DESCRIPTION
### Motivation
- Remove the personal name and reduce prominence of the student status to present a more senior-facing public profile for recruiters.
- Reflect the website's current focus by emphasizing Reverse Engineering and Malware Development as primary specializations.
- Preserve existing signals of credibility such as certifications, badges, and tooling to retain trust and technical context.

### Description
- Rewrote `README.md` header to an anonymous professional title and added website/blog shields while keeping the Buenos Aires location visible.
- De-emphasized the CS student line by moving academic background to a less prominent place and keeping the rest of the experience foregrounded.
- Amplified Reverse Engineering and Malware Development content in the `About` and `Focus Areas` sections to reflect current priorities.
- Kept certifications, embedded badges, tooling shields, and contact links intact to maintain existing provenance and tool signals.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2d8545fc832ab6666d72e58ab5e3)